### PR TITLE
Add basic DevSpace config using poetry to cookiecutter template

### DIFF
--- a/{{cookiecutter.project_slug}}/.dockerignore
+++ b/{{cookiecutter.project_slug}}/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+
+# Ignore .git folder
+.git

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -130,3 +130,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore DevSpace cache and log folder
+.devspace/
+
+# Ignore any kubeconfig that might be created locally
+kubeconfig.yaml

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.9.7-slim-buster as development
+
+# Create project directory (workdir)
+WORKDIR /app
+
+# Add pyproject.toml to WORKDIR and install dependencies
+COPY pyproject.toml .
+RUN pip install poetry && poetry install
+
+# Add source code files to WORKDIR
+ADD . .
+
+# Application port (optional)
+EXPOSE 8080
+
+# Container start command
+# It is also possible to override this in devspace.yaml via images.*.cmd
+CMD ["poetry", "run", "python", "src/{{cookiecutter.project_slug}}/main.py"]

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -17,7 +17,12 @@
 
 ### Getting Started
 1. Run `poetry shell`
-2. Start adding new python files to `src` and new tests to `tests`
+2. Modify the project name and authors in [pyproject.toml](./pyproject.toml)
+3. Start adding new python files to [src](./src) and new tests to [tests](./tests)
+4. (Optional) If using DevSpace:
+    * Run `devspace use context` to select the proper cluster.
+	* Run `devspace use namespace my-namespace` to select the namespace to use.
+	* Start your project in development mode with `devspace dev`.
 
 ### Running Dev Tools
 1. Change to the base directory

--- a/{{cookiecutter.project_slug}}/devspace.yaml
+++ b/{{cookiecutter.project_slug}}/devspace.yaml
@@ -1,0 +1,89 @@
+version: v1beta11
+
+# `vars` specifies variables which may be used as ${VAR_NAME} in devspace.yaml
+vars:
+- name: IMAGE
+  value: username/app
+
+# `deployments` tells DevSpace how to deploy this project
+deployments:
+- name: "{{ cookiecutter.project_slug.replace('_', '-') }}",
+  # This deployment uses `helm` but you can also define `kubectl` deployments or kustomizations
+  helm:
+    # We are deploying the so-called Component Chart: https://devspace.sh/component-chart/docs
+    componentChart: true
+    # Under `values` we can define the values for this Helm chart used during `helm install/upgrade`
+    # You may also use `valuesFiles` to load values from files, e.g. valuesFiles: ["values.yaml"]
+    values:
+      containers:
+      - image: ${IMAGE} # Use the value of our `${IMAGE}` variable here (see vars above)
+      service:
+        ports:
+        - port: 8080
+
+# `dev` only applies when you run `devspace dev`
+dev:
+  # `dev.ports` specifies all ports that should be forwarded while `devspace dev` is running
+  # Port-forwarding lets you access your application via localhost on your local machine
+  ports:
+  - imageSelector: ${IMAGE} # Select the Pod that runs our `${IMAGE}`
+    forward:
+    - port: 8080
+
+  # `dev.open` tells DevSpace to open certain URLs as soon as they return HTTP status 200
+  # Since we configured port-forwarding, we can use a localhost address here to access our application
+  open:
+  - url: http://localhost:8080
+
+  # `dev.sync` configures a file sync between our Pods in k8s and your local project files
+  sync:
+  - imageSelector: ${IMAGE} # Select the Pod that runs our `${IMAGE}`
+    localSubPath: ./
+    containerPath: /app
+    excludePaths:
+    - .git/
+    uploadExcludePaths:
+    - Dockerfile
+
+  # `dev.terminal` tells DevSpace to open a terminal as a last step during `devspace dev`
+  terminal:
+    imageSelector: ${IMAGE} # Select the Pod that runs our `${IMAGE}`
+    # With this optional `command` we can tell DevSpace to run a script when opening the terminal
+    # This is often useful to display help info for new users or perform initial tasks (e.g. installing dependencies)
+    # DevSpace has generated an example ./devspace_start.sh file in your local project - Feel free to customize it!
+    command:
+    - ./devspace_start.sh
+
+  # Since our Helm charts and manifests deployments are often optimized for production,
+  # DevSpace let's you swap out Pods dynamically to get a better dev environment
+  replacePods:
+  - imageSelector: ${IMAGE} # Select the Pod that runs our `${IMAGE}`
+    # Since the `${IMAGE}` used to start our main application pod may be distroless or not have any dev tooling, let's replace it with a dev-optimized image
+    # DevSpace provides a sample image here but you can use any image for your specific needs
+    replaceImage: loftsh/python:latest
+    # Besides replacing the container image, let's also apply some patches to the `spec` of our Pod
+    # We are overwriting `command` + `args` for the first container in our selected Pod, so it starts with `sleep 9999999`
+    # Using `sleep 9999999` as PID 1 (instead of the regular ENTRYPOINT), allows you to start the application manually
+    patches:
+    - op: replace
+      path: spec.containers[0].command
+      value:
+      - sleep
+    - op: replace
+      path: spec.containers[0].args
+      value:
+      - "9999999"
+    - op: remove
+      path: spec.containers[0].securityContext
+
+# `profiles` lets you modify the config above for different environments (e.g. dev vs production)
+profiles:
+  # This profile is called `production` and you can use it for example using: devspace deploy -p production
+  # We generally recommend to use the base config without any profiles as optimized for development (e.g. image build+push is disabled)
+- name: production
+# This profile adds our image to the config so that DevSpace will build, tag and push our image before the deployment
+  merge:
+    images:
+      app:
+        image: ${IMAGE} # Use the value of our `${IMAGE}` variable here (see vars above)
+        dockerfile: ./Dockerfile

--- a/{{cookiecutter.project_slug}}/devspace_start.sh
+++ b/{{cookiecutter.project_slug}}/devspace_start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set +e  # Continue on errors
+
+if [ -f "pyproject.toml" ]; then
+   echo "Installing Python Dependencies"
+   pip install poetry && poetry install
+fi
+
+COLOR_CYAN="\033[0;36m"
+COLOR_RESET="\033[0m"
+
+echo -e "${COLOR_CYAN}
+   ____              ____
+  |  _ \  _____   __/ ___| _ __   __ _  ___ ___
+  | | | |/ _ \ \ / /\___ \| '_ \ / _\` |/ __/ _ \\
+  | |_| |  __/\ V /  ___) | |_) | (_| | (_|  __/
+  |____/ \___| \_/  |____/| .__/ \__,_|\___\___|
+                          |_|
+${COLOR_RESET}
+Welcome to your development container!
+
+This is how you can work with it:
+- Run \`${COLOR_CYAN}poetry run python src/{{cookiecutter.project_slug}}/main.py${COLOR_RESET}\` to build the application
+- ${COLOR_CYAN}Files will be synchronized${COLOR_RESET} between your local machine and this container
+- Some ports will be forwarded, so you can access this container on your local machine via ${COLOR_CYAN}http://localhost:8080${COLOR_RESET}
+"
+
+bash

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/main.py
@@ -1,0 +1,10 @@
+"""{{ cookiecutter.project_name }} main."""
+
+
+def hi():
+    """Say hi in the terminal."""
+    print("Hi from main.py!")
+
+
+if __name__ == "__main__":
+    hi()

--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -5,3 +5,10 @@ import {{cookiecutter.project_slug}}
 def test_version():
     """Verify the {{ cookiecutter.project_slug }} package version."""
     assert {{cookiecutter.project_slug}}.__version__ == "{{ cookiecutter.version }}"
+
+
+def test_print_output(capfd):
+    """Verify the print output of hi()."""
+    {{cookiecutter.project_slug}}.main.hi()
+    out, err = capfd.readouterr()
+    assert out == "Hi from main.py!\n"


### PR DESCRIPTION
Adds a basic DevSpace config using poetry that can immediately be used by developers by running `devspace up`.

Cookiecutter version of #3 

Closes DEV-205