### PR TITLE
Don't try to render workflows during cookiecutter

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,8 @@
 		"FastAPI application",
 		"Python package"
 	],
-	"version": "0.1.0"
+	"version": "0.1.0",
+	"_copy_without_render": [
+          "*.github/workflows/*",
+        ]
 }


### PR DESCRIPTION
Purposefully omit the GitHub Actions workflows from cookiecutter rendering with Jinja2 so that workflow variables are left intact.

![image](https://user-images.githubusercontent.com/205707/140379361-74476281-0b50-49f0-af1b-e68d2fd2502d.png)
