### PR TITLE
Remove errant comma in deployment name

### DIFF
--- a/{{cookiecutter.hyphenated}}/devspace.yaml
+++ b/{{cookiecutter.hyphenated}}/devspace.yaml
@@ -7,7 +7,7 @@ vars:
 
 # `deployments` tells DevSpace how to deploy this project
 deployments:
-- name: "{{ cookiecutter.hyphenated }}",
+- name: "{{ cookiecutter.hyphenated }}"
   # This deployment uses `helm` but you can also define `kubectl` deployments or kustomizations
   helm:
     # We are deploying the so-called Component Chart: https://devspace.sh/component-chart/docs


### PR DESCRIPTION
Remove comma in devspace.yaml deployments[0].name which was causing a connection error.

Fixes #13