### PR TITLE
Set executable permissions and use poetry run dev in devspace_start.sh

### DIFF
--- a/{{cookiecutter.hyphenated}}/devspace_start.sh
+++ b/{{cookiecutter.hyphenated}}/devspace_start.sh
@@ -20,7 +20,7 @@ ${COLOR_RESET}
 Welcome to your development container!
 
 This is how you can work with it:
-- Run \`${COLOR_CYAN}poetry run python src/{{cookiecutter.underscored}}/main.py${COLOR_RESET}\` to build the application
+- Run \`${COLOR_CYAN}poetry run dev${COLOR_RESET}\` to build the application
 - ${COLOR_CYAN}Files will be synchronized${COLOR_RESET} between your local machine and this container
 - Some ports will be forwarded, so you can access this container on your local machine via ${COLOR_CYAN}http://localhost:8000${COLOR_RESET}
 "


### PR DESCRIPTION
- Make `devspace_start.sh` executable.
- Change `devspace_start.sh` command to `poetry run dev` which ensures relative import paths in python files are resolved correctly.

Fixes #17 #18