### PR TITLE
Fix flake8-black version and missing requests

### DIFF
--- a/{{cookiecutter.hyphenated}}/pyproject.toml
+++ b/{{cookiecutter.hyphenated}}/pyproject.toml
@@ -9,7 +9,7 @@ version = "{{ cookiecutter.version }}"
 dev = "{{cookiecutter.underscored}}.main:dev_start"
 {% endif %}
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 {% if cookiecutter.project_type == 'FastAPI application' %} fastapi = "^0.65.2"
 uvicorn = "^0.14.0"
 python-multipart = "^0.0.5"
@@ -19,11 +19,11 @@ loguru = "^0.5.3"
 {% endif %}
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.0"
-black = "^20.8b1"
+black = "22.1.0"
 coverage = {extras = ["toml"], version = "^5.5"}
 flake8 = "^3.9.0"
 flake8-bandit = "^2.1.2"
-flake8-black = "^0.2.1"
+flake8-black = "^0.3.2"
 flake8-bugbear = "^21.4.3"
 flake8-comprehensions = "^3.4.0"
 flake8-docstrings = "^1.6.0"
@@ -35,6 +35,8 @@ pep8-naming = "^0.11.1"
 pytest = "^6.2.3"
 pytest-cov = "^2.11.1"
 pytest-mock = "^3.5.1"
+{% if cookiecutter.project_type == 'FastAPI application' %}requests = "^2.27.1"
+{% endif %}
 rope = "^0.19.0"
 safety = "^1.10.3"
 xdoctest = "^0.15.4"

--- a/{{cookiecutter.hyphenated}}/pyproject.toml
+++ b/{{cookiecutter.hyphenated}}/pyproject.toml
@@ -10,7 +10,7 @@ dev = "{{cookiecutter.underscored}}.main:dev_start"
 {% endif %}
 [tool.poetry.dependencies]
 python = "^3.7"
-{% if cookiecutter.project_type == 'FastAPI application' %} fastapi = "^0.65.2"
+{% if cookiecutter.project_type == 'FastAPI application' %}fastapi = "^0.65.2"
 uvicorn = "^0.14.0"
 python-multipart = "^0.0.5"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}


### PR DESCRIPTION
- Update `black` and `flake8-black`.
- Add requests as a dev dependency.
- Remove whitespace around `fastapi`.

Closes #20