### PR TITLE
Initial unit tests for cookiecutter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI - Validate cookiecutter
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        python-version: [3.9]
+        poetry-version: [1.1.11]
+        os: [ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Install and configure poetry
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+          version: ${{ matrix.poetry-version }}
+
+      # Load cached venv if cache exists
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      # Install dependencies if cache does not exist
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction
+
+      - name: Run unit tests
+        run: poetry run pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+authors = [
+  "Lucas Melin <mell@bank-banque-canada.ca>",
+  "Steven Lougheed <lous@bank-banque-canada.ca>",
+  "Marcelo Katayama <katm@bank-banque-canada.ca>",
+]
+description = "A starter project template for new python development"
+name = "template-python-project"
+readme = "README.md"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+cookiecutter = "^1.7.3"
+pytest-cookies = "^0.6.1"
+
+[tool.poetry.dev-dependencies]
+black = "22.1.0"
+pytest = "^6.2.3"
+
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0"]

--- a/tests/test_cookecutter_template.py
+++ b/tests/test_cookecutter_template.py
@@ -70,3 +70,23 @@ def test_bake_and_run_nox(cookies, command):
         project_path = str(result.project_path)
         assert run_inside_dir("poetry install --no-interaction", project_path) == 0
         assert run_inside_dir(f"poetry run nox -rs {command}", project_path) == 0
+
+
+def test_bake_fastapi_application(cookies):
+    context = {"project_type": "FastAPI application"}
+    result = cookies.bake(extra_context=context)
+    pyproject_path = result.project_path / "pyproject.toml"
+    with pyproject_path.open("r") as pyproject_file:
+        contents = pyproject_file.read()
+        assert "fastapi" in contents
+        assert "tool.poetry.scripts" in contents
+
+
+def test_bake_python_package(cookies):
+    context = {"project_type": "Python package"}
+    result = cookies.bake(extra_context=context)
+    pyproject_path = result.project_path / "pyproject.toml"
+    with pyproject_path.open("r") as pyproject_file:
+        contents = pyproject_file.read()
+        assert "fastapi" not in contents
+        assert "tool.poetry.scripts" not in contents

--- a/tests/test_cookecutter_template.py
+++ b/tests/test_cookecutter_template.py
@@ -1,0 +1,76 @@
+from contextlib import contextmanager
+import shlex
+import os
+import subprocess
+from cookiecutter.utils import rmtree
+
+
+@contextmanager
+def inside_dir(dirpath):
+    """
+    Execute code from inside the given directory
+    :param dirpath: String, path of the directory the command is being run.
+    """
+    old_path = os.getcwd()
+    try:
+        os.chdir(dirpath)
+        yield
+    finally:
+        os.chdir(old_path)
+
+
+@contextmanager
+def bake_in_temp_dir(cookies, *args, **kwargs):
+    """
+    Delete the temporary directory that is created when executing the tests
+    :param cookies: pytest_cookies.Cookies,
+        cookie to be baked
+    """
+    result = cookies.bake(*args, **kwargs)
+    try:
+        yield result
+    finally:
+        rmtree(str(result.project_path))
+
+
+def run_inside_dir(command, dirpath):
+    """
+    Run a command from inside a given directory, returning the exit status
+    :param command: Command that will be executed
+    :param dirpath: String, path of the directory the command is being run.
+    """
+    with inside_dir(dirpath):
+        return subprocess.check_call(shlex.split(command))
+
+
+def check_output_inside_dir(command, dirpath):
+    """
+    Run a command from inside a given directory, returning the command output
+    :param command: Command that will be executed
+    :param dirpath: String, path of the directory the command is being run.
+    """
+    with inside_dir(dirpath):
+        return subprocess.check_output(shlex.split(command))
+
+
+def test_bake_with_defaults(cookies):
+    with bake_in_temp_dir(cookies) as result:
+        assert result.project_path.is_dir()
+        assert result.exit_code == 0
+        assert result.exception is None
+
+
+def test_bake_and_run_tests(cookies):
+    with bake_in_temp_dir(cookies) as result:
+        assert result.project_path.is_dir()
+        project_path = str(result.project_path)
+        assert run_inside_dir("poetry install --no-interaction", project_path) == 0
+        assert run_inside_dir("poetry run nox -rs tests", project_path) == 0
+
+
+def test_bake_and_run_lint(cookies):
+    with bake_in_temp_dir(cookies) as result:
+        assert result.project_path.is_dir()
+        project_path = str(result.project_path)
+        assert run_inside_dir("poetry install --no-interaction", project_path) == 0
+        assert run_inside_dir("poetry run nox -rs lint", project_path) == 0

--- a/tests/test_cookecutter_template.py
+++ b/tests/test_cookecutter_template.py
@@ -69,7 +69,7 @@ def test_bake_and_run_nox(cookies, command):
         assert result.project_path.is_dir()
         project_path = str(result.project_path)
         assert run_inside_dir("poetry install --no-interaction", project_path) == 0
-        assert run_inside_dir(f"poetry run nox -rs {command}", project_path) == 0
+        assert run_inside_dir(f"poetry run nox -s {command}", project_path) == 0
 
 
 def test_bake_fastapi_application(cookies):

--- a/tests/test_cookecutter_template.py
+++ b/tests/test_cookecutter_template.py
@@ -3,7 +3,7 @@ import shlex
 import os
 import subprocess
 from cookiecutter.utils import rmtree
-
+import pytest
 
 @contextmanager
 def inside_dir(dirpath):
@@ -60,17 +60,13 @@ def test_bake_with_defaults(cookies):
         assert result.exception is None
 
 
-def test_bake_and_run_tests(cookies):
+commands = ["black", "docs", "lint", "safety", "tests"]
+
+
+@pytest.mark.parametrize("command", commands, ids=commands)
+def test_bake_and_run_nox(cookies, command):
     with bake_in_temp_dir(cookies) as result:
         assert result.project_path.is_dir()
         project_path = str(result.project_path)
         assert run_inside_dir("poetry install --no-interaction", project_path) == 0
-        assert run_inside_dir("poetry run nox -rs tests", project_path) == 0
-
-
-def test_bake_and_run_lint(cookies):
-    with bake_in_temp_dir(cookies) as result:
-        assert result.project_path.is_dir()
-        project_path = str(result.project_path)
-        assert run_inside_dir("poetry install --no-interaction", project_path) == 0
-        assert run_inside_dir("poetry run nox -rs lint", project_path) == 0
+        assert run_inside_dir(f"poetry run nox -rs {command}", project_path) == 0

--- a/{{cookiecutter.hyphenated}}/noxfile.py
+++ b/{{cookiecutter.hyphenated}}/noxfile.py
@@ -1,11 +1,10 @@
 """Nox sessions."""
-
 import tempfile
 from pathlib import Path
 
 import nox
 
-package = "{{cookiecutter.underscored}}"
+package = "{{cookiecutter.hyphenated}}"
 nox.options.sessions = "lint", "safety", "tests"
 locations = "src", "tests", "noxfile.py"
 
@@ -57,7 +56,7 @@ def lint(session):
         "flake8-bugbear",
         "flake8-comprehensions",
         "flake8-docstrings",
-        "flake8-import-order"
+        "flake8-import-order",
     )
     session.run("isort", "--check", "--diff", "--profile", "black", *args)
     session.run("flake8", *args)

--- a/{{cookiecutter.hyphenated}}/pyproject.toml
+++ b/{{cookiecutter.hyphenated}}/pyproject.toml
@@ -22,7 +22,7 @@ bandit = "^1.7.0"
 black = "22.1.0"
 coverage = {extras = ["toml"], version = "^5.5"}
 flake8 = "^3.9.0"
-flake8-bandit = "^2.1.2"
+flake8-bandit = "^3.0.0"
 flake8-black = "^0.3.2"
 flake8-bugbear = "^21.4.3"
 flake8-comprehensions = "^3.4.0"

--- a/{{cookiecutter.hyphenated}}/src/{{cookiecutter.underscored}}/main.py
+++ b/{{cookiecutter.hyphenated}}/src/{{cookiecutter.underscored}}/main.py
@@ -7,8 +7,7 @@ def hi():
 
 
 if __name__ == "__main__":
-    hi()
-{% elif cookiecutter.project_type == 'FastAPI application' %}"""Main FastAPI application."""
+    hi(){% elif cookiecutter.project_type == 'FastAPI application' %}"""Main FastAPI application."""
 import os
 import sys
 from datetime import timedelta
@@ -123,5 +122,4 @@ def dev_start():
     else:
         uvicorn.run(
             "{{cookiecutter.underscored}}.main:app", host="localhost", port=8000, reload=True
-        )
-{% endif %}
+        ){% endif %}

--- a/{{cookiecutter.hyphenated}}/tests/test_main.py
+++ b/{{cookiecutter.hyphenated}}/tests/test_main.py
@@ -69,5 +69,4 @@ def test_get_token_nonexistant_user(client: TestClient):
     response = client.post("/token", data=login_data)
     tokens = response.json()
     assert response.status_code == 401
-    assert "access_token" not in tokens
-{% endif %}
+    assert "access_token" not in tokens{% endif %}


### PR DESCRIPTION
Test basic project creation as well as the `lint` and `tests` nox sessions in the created project. Because the tests run through a `poetry install` followed by a nox session, these can take some time to run (locally it was about 60 seconds).

Fixes #23