### PR TITLE
Update dependencies to the latest versions

### DIFF
--- a/{{cookiecutter.hyphenated}}/pyproject.toml
+++ b/{{cookiecutter.hyphenated}}/pyproject.toml
@@ -10,36 +10,35 @@ dev = "{{cookiecutter.underscored}}.main:dev_start"
 {% endif %}
 [tool.poetry.dependencies]
 python = "^3.7"
-{% if cookiecutter.project_type == 'FastAPI application' %}fastapi = "^0.65.2"
-uvicorn = "^0.14.0"
+{% if cookiecutter.project_type == 'FastAPI application' %}fastapi = "^0.75.0"
+uvicorn = "^0.17.6"
 python-multipart = "^0.0.5"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 passlib = {extras = ["bcrypt"], version = "^1.7.4"}
-loguru = "^0.5.3"
+loguru = "^0.6.0"
 {% endif %}
 [tool.poetry.dev-dependencies]
-bandit = "^1.7.0"
-black = "22.1.0"
-coverage = {extras = ["toml"], version = "^5.5"}
-flake8 = "^3.9.0"
+bandit = "^1.7.4"
+black = "^22.1.0"
+coverage = {extras = ["toml"], version = "^6.3.2"}
+flake8 = "^4.0.1"
 flake8-bandit = "^3.0.0"
 flake8-black = "^0.3.2"
-flake8-bugbear = "^21.4.3"
-flake8-comprehensions = "^3.4.0"
+flake8-bugbear = "^22.1.11"
+flake8-comprehensions = "^3.8.0"
 flake8-docstrings = "^1.6.0"
 flake8-import-order = "^0.18.1"
-mkdocs-material = "^7.1.3"
-mkdocstrings = "^0.15.0"
-nox = "^2020.12.31"
-pep8-naming = "^0.11.1"
-pytest = "^6.2.3"
-pytest-cov = "^2.11.1"
-pytest-mock = "^3.5.1"
-{% if cookiecutter.project_type == 'FastAPI application' %}requests = "^2.27.1"
-{% endif %}
-rope = "^0.19.0"
+mkdocs-material = "^8.2.5"
+mkdocstrings = "^0.18.1"
+nox = "^2022.1.7"
+pep8-naming = "^0.12.1"
+pytest = "^7.1.0"
+pytest-cov = "^3.0.0"
+pytest-mock = "^3.7.0"
+{% if cookiecutter.project_type == 'FastAPI application' %}requests = "^2.27.1"{% endif %}
+rope = "^0.23.0"
 safety = "^1.10.3"
-xdoctest = "^0.15.4"
+xdoctest = "^0.15.10"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Assuming we're still supporting python 3.7 for now, update all packages to the latest available versions.

The unit tests should help us out here with the validation - they ran well locally for me.